### PR TITLE
ブラウザのサジェストワードを選択した場合も、リクエストが実行されるよう修正した

### DIFF
--- a/app/javascript/controllers/search_form_controller.js
+++ b/app/javascript/controllers/search_form_controller.js
@@ -7,13 +7,11 @@ export default class extends Controller {
       return;
     }
 
-    if (event.data !== undefined) {
-      clearTimeout(this.timeout);
+    clearTimeout(this.timeout);
 
-      this.timeout = setTimeout(() => {
-        this.eventData = event.data;
-        this.element.requestSubmit();
-      }, 200);
-    }
+    this.timeout = setTimeout(() => {
+      this.eventData = event.data;
+      this.element.requestSubmit();
+    }, 200);
   }
 }


### PR DESCRIPTION
ラジオボタン変更時にリクエストが実行されないよう、記述していたコードが原因で、ブラウザがサジェストしてくれるワードを選択した際にリクエストが実行されず、インクリメンタルサーチができなくなっていた。
ラジオボタン変更時にリクエストが実行されるのは、許容範囲だと判断したので修正した。
